### PR TITLE
Add parameters for setting request timeout.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tibber-httpclient",
-  "version": "1.13.6",
+  "version": "1.14.0",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
Add parameters for setting request timeout.
related to Post Mortem: https://www.notion.so/tibber/App-down-limiter-lock-issue-69b641af75b448a7a7edc3d04f5aef8d
 Adding more tools to the toolbox to set a timeout on the request level.

```js
  public async get<T>(route: string, timeout: number): Promise<T> {
    return await this._request("GET", route, undefined, timeout);
  }

  public async post<T>(route: string, payload?: object, timeout?: number): Promise<T> {
    return await this._request("POST", route, payload, timeout);
  }

  public async patch<T>(route: string, payload?: object, timeout?: number): Promise<T> {
    return await this._request("PATCH", route, payload);
  }

  public async put<T>(route: string, payload: object, timeout?: number): Promise<T> {
    return await this._request("PUT", route, payload, timeout);
  }

  public async delete(route: string, timeout?: number) {
    return await this._request("DELETE", route, undefined, timeout);
  }
```