### PR TITLE
v.3.1.1: fix CVEs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -26,7 +26,10 @@ jobs:
             yarn
             yarn test
             yarn build
-
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
   publish:
     working_directory: ~/package
     docker:


### PR DESCRIPTION
- Bump http-cache-semantics from 4.1.0 to 4.1.1
- Bump json5 from 1.0.1 to 1.0.2
- only publish package from `master`
