### PR TITLE
fix logger selection against minification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tibber-httpclient",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "author": "Tibber",

--- a/src/http-client.test.ts
+++ b/src/http-client.test.ts
@@ -1,5 +1,6 @@
 import { CancelError, HTTPError } from 'got';
 import { createServer, Server } from 'http';
+import { Logger } from './interfaces';
 import { HttpClient, TestHttpClient, RequestException } from './http-client';
 
 const Port = 38080;
@@ -41,6 +42,11 @@ describe('http client', () => {
             res.setHeader('Content-Type', 'application/json');
             res.end(JSON.stringify({ ok: true }));
           }
+          break;
+        case '/logger-json':
+          res.statusCode = 200;
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ ok: true }));
           break;
         default:
           res.statusCode = 200;
@@ -176,6 +182,85 @@ describe('http client', () => {
       expect(error.innerError.options.headers.nonheader).toBe('abc');
       expect(error.innerError.options.headers.test).toBe('123');
     }
+  });
+
+  describe('logger adapter selection', () => {
+    let mockLogger: jest.Mocked<Logger>;
+
+    beforeEach(() => {
+      mockLogger = {
+        info: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+      } as jest.Mocked<Logger>;
+    });
+
+    test('uses PinoLogger when loggerAdapter is pino', async () => {
+      const client = new HttpClient({
+        prefixUrl: ServerUrl,
+        logger: mockLogger,
+        loggerAdapter: 'pino',
+      });
+      await client.get('logger-json');
+      expect(mockLogger.debug).toHaveBeenCalled();
+      const [structured] = mockLogger.debug.mock.calls[0];
+      expect(structured).toEqual(
+        expect.objectContaining({
+          req: expect.objectContaining({ method: 'GET' }),
+          res: expect.objectContaining({ statusCode: 200 }),
+          responseTime: expect.any(Number),
+        }),
+      );
+    });
+
+    test('uses GenericLogger when loggerAdapter is generic', async () => {
+      const client = new HttpClient({
+        prefixUrl: ServerUrl,
+        logger: mockLogger,
+        loggerAdapter: 'generic',
+      });
+      await client.get('logger-json');
+      expect(mockLogger.debug).toHaveBeenCalled();
+      const [firstLine] = mockLogger.debug.mock.calls[0];
+      expect(typeof firstLine).toBe('string');
+      expect(firstLine).toMatch(/^GET /);
+    });
+
+    test('uses PinoLogger when loggerAdapter is omitted and logger constructor name is Pino', async () => {
+      class Pino implements Logger {
+        info = jest.fn();
+
+        debug = jest.fn();
+
+        error = jest.fn();
+      }
+      const pinoLikeLogger = new Pino();
+      const client = new HttpClient({
+        prefixUrl: ServerUrl,
+        logger: pinoLikeLogger,
+      });
+      await client.get('logger-json');
+      expect(pinoLikeLogger.debug).toHaveBeenCalled();
+      const [structured] = (pinoLikeLogger.debug as jest.Mock).mock.calls[0];
+      expect(structured).toEqual(
+        expect.objectContaining({
+          req: expect.objectContaining({ method: 'GET' }),
+          res: expect.objectContaining({ statusCode: 200 }),
+          responseTime: expect.any(Number),
+        }),
+      );
+    });
+
+    test('uses GenericLogger when loggerAdapter is omitted and constructor name is not Pino', async () => {
+      const client = new HttpClient({
+        prefixUrl: ServerUrl,
+        logger: mockLogger,
+      });
+      await client.get('logger-json');
+      const [firstLine] = mockLogger.debug.mock.calls[0];
+      expect(typeof firstLine).toBe('string');
+      expect(firstLine).toMatch(/^GET /);
+    });
   });
 
   test('Can clear TestHttpClient calls', async () => {

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -78,6 +78,13 @@ export class ProblemDetailsError extends RequestException {
 export type HttpClientInitParams = {
   prefixUrl?: string;
   logger?: Logger;
+  /**
+   * The logger adapter to use.
+   *
+   * Not having this set will have it fallback
+   * to check if the constructor name is Pino
+   */
+  loggerAdapter?: 'pino' | 'generic';
   config?: HttpClientConfig;
   options?: OptionsInit;
   headerFunc?: HeaderFunction;
@@ -133,10 +140,21 @@ export class HttpClient implements IHttpClient {
     }
 
     if (initParams?.logger) {
-      this.#logger =
-        initParams.logger.constructor?.name === 'Pino'
-          ? new PinoLogger(initParams.logger)
-          : new GenericLogger(initParams.logger);
+      // Prefer explicit logger adapter from config instead
+      // of relying on constructor name which may break
+      // if the code which consumes this package is minified
+      if (initParams.loggerAdapter) {
+        if (initParams.loggerAdapter === 'pino') {
+          this.#logger = new PinoLogger(initParams.logger);
+        } else {
+          this.#logger = new GenericLogger(initParams.logger);
+        }
+      } else {
+        this.#logger =
+          initParams.logger.constructor?.name === 'Pino'
+            ? new PinoLogger(initParams.logger)
+            : new GenericLogger(initParams.logger);
+      }
     }
 
     if (initParams?.headerFunc) {


### PR DESCRIPTION
The logic for selecting pino or a generic logger relies on the Constructor name not being modified by the code which consumes it. Thi is not well documented and leads to odd scenarios for consumers. In next.js for example it will act differently when running locally and when the app is deployed.

PR solves this by introducing an optional `loggerAdapter` param which takes precedence over the constructor-check logic. I think this is fine since the interface struct is the same regardless of adapter.