### PR TITLE
Log connection-level request failures with meaningful messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tibber-httpclient",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "author": "Tibber",

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -1,6 +1,6 @@
 import http from 'node:http';
 import https from 'node:https';
-import got, { Response, Got, CancelableRequest, HTTPError, CancelError, Method, Headers, OptionsInit } from 'got';
+import got, { Response, Got, CancelableRequest, HTTPError, CancelError, Method, Headers, OptionsInit, RequestError } from 'got';
 import NodeCache from 'node-cache';
 import { HttpClientConfig, HttpLogger, IHttpClient, Logger, RequestOptions } from './interfaces';
 import { GenericLogger, NoOpLogger, PinoLogger } from './loggers';
@@ -191,9 +191,13 @@ export class HttpClient implements IHttpClient {
 
   #logAndCreateError({ error, path }: { error: unknown; path: string }) {
     let code;
+    if (error instanceof RequestError) {
+      // covers HTTPError and CancelError, but also connection-level failures
+      // (timeouts, ECONNREFUSED, ...) that never produce a response
+      this.#logger.logFailure(error);
+    }
     if (error instanceof HTTPError || error instanceof CancelError) {
       code = error.response?.statusCode ?? error.code;
-      this.#logger.logFailure(error);
       const contentType = error.response?.headers['content-type'] ?? '';
       if (
         (contentType.includes('application/problem+json') || contentType.includes('application/json')) &&

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -192,8 +192,7 @@ export class HttpClient implements IHttpClient {
   #logAndCreateError({ error, path }: { error: unknown; path: string }) {
     let code;
     if (error instanceof RequestError) {
-      // covers HTTPError and CancelError, but also connection-level failures
-      // (timeouts, ECONNREFUSED, ...) that never produce a response
+      // base class of HTTPError/CancelError — also catches connection-level failures
       this.#logger.logFailure(error);
     }
     if (error instanceof HTTPError || error instanceof CancelError) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-import { CancelError, HTTPError, OptionsInit, Response } from 'got/dist/source';
+import { OptionsInit, RequestError, Response } from 'got/dist/source';
 
 export interface Logger {
   info(...args: unknown[]): void;
@@ -8,7 +8,7 @@ export interface Logger {
 
 export interface HttpLogger {
   logSuccess(response: Response, options: RequestOptions): void;
-  logFailure(error: HTTPError | CancelError): void;
+  logFailure(error: RequestError): void;
 }
 
 type GotOptions = Pick<

--- a/src/loggers.test.ts
+++ b/src/loggers.test.ts
@@ -1,5 +1,5 @@
 import each from 'jest-each';
-import { Response, HTTPError } from 'got/dist/source';
+import { Response, HTTPError, RequestError } from 'got/dist/source';
 import { redact, redactSensitiveHeaders, redactSensitiveProps, PinoLogger } from './loggers';
 import { RequestOptions, Logger } from './interfaces';
 
@@ -202,6 +202,40 @@ describe('PinoLogger', () => {
         responseTime: 300,
       });
       expect(message).toBe('POST https://api.example.com/users 500 Internal Server Error 300ms');
+    });
+
+    it('should log a meaningful message for connection errors without request, response or timings', () => {
+      const mockError = {
+        name: 'TimeoutError',
+        options: {
+          method: 'POST',
+          url: 'https://api.example.com/users',
+        },
+        message: "Timeout awaiting 'request' for 10000ms",
+        code: 'ETIMEDOUT',
+      } as unknown as RequestError;
+
+      pinoLogger.logFailure(mockError);
+
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
+      const [structuredData, message] = mockLogger.error.mock.calls[0];
+
+      expect(message).toBe('POST https://api.example.com/users ETIMEDOUT TimeoutError');
+      expect(message).not.toContain('undefined');
+      expect(structuredData).toEqual({
+        req: {
+          method: 'POST',
+          url: 'https://api.example.com/users',
+          failed: true,
+        },
+        res: {
+          failed: true,
+        },
+        err: {
+          message: "Timeout awaiting 'request' for 10000ms",
+          code: 'ETIMEDOUT',
+        },
+      });
     });
   });
 });

--- a/src/loggers.test.ts
+++ b/src/loggers.test.ts
@@ -155,14 +155,9 @@ describe('PinoLogger', () => {
       const mockError = {
         options: {
           method: 'POST',
+          url: 'https://api.example.com/users',
           headers: { 'content-type': 'application/json' },
           json: { name: 'test' }
-        },
-        request: {
-          options: {
-            method: 'POST',
-            url: 'https://api.example.com/users'
-          }
         },
         response: {
           statusCode: 500,

--- a/src/loggers.ts
+++ b/src/loggers.ts
@@ -1,4 +1,4 @@
-import { CancelError, HTTPError, Response } from 'got/dist/source';
+import { RequestError, Response } from 'got/dist/source';
 import copy from 'fast-copy';
 import { genericLogRedactionKeyPatterns } from './log-redaction';
 import { HttpLogger, Logger, RequestOptions } from './interfaces';
@@ -8,7 +8,7 @@ export class NoOpLogger implements HttpLogger {
   logSuccess(_response: Response, _options: RequestOptions): void {}
 
   // eslint-disable-next-line class-methods-use-this
-  logFailure(_error: HTTPError | CancelError): void {}
+  logFailure(_error: RequestError): void {}
 }
 
 const tryStringifyJSON = (data: object | undefined | null, onfailureResult?: string): string=>{
@@ -43,9 +43,9 @@ export class GenericLogger implements HttpLogger {
     this.#logger.debug('request-options', tryStringifyJSON(redactedOptions).replace(/\\n/g, ''));
   }
 
-  logFailure(error: HTTPError | CancelError): void {
+  logFailure(error: RequestError): void {
     const { context, headers, method } = error.options;
-    const { requestUrl } = error.request ?? {};
+    const requestUrl = error.request?.requestUrl ?? error.options.url;
     const code = error.response?.statusCode ?? error.code;
     const { start, end, error: err } = error?.timings ?? {};
     const duration = err && end && start ? (err ?? end) - start : undefined;
@@ -89,16 +89,21 @@ export class PinoLogger implements HttpLogger {
     }, message);
   }
 
-  logFailure(error: HTTPError | CancelError): void {
+  logFailure(error: RequestError): void {
     const { response: res, request: req, timings } = error;
-    const responseTime = Number(timings?.end) - Number(timings?.start);
+    // requests that never connect have no request/response/timings — fall back to
+    // the always-present options so the message never interpolates undefined
+    const method = req?.options?.method ?? error.options.method;
+    const url = req?.options?.url ?? error.options.url;
+    const responseTimeMs = Number(timings?.end) - Number(timings?.start);
+    const responseTime = Number.isNaN(responseTimeMs) ? undefined : responseTimeMs;
     const statusCode = res?.statusCode ?? error.code;
-    const statusMessage = res?.statusMessage ?? 'Error';
-    const message = `${req?.options?.method} ${req?.options?.url} ${statusCode} ${statusMessage} ${responseTime}ms`;
+    const statusMessage = res?.statusMessage ?? error.name;
+    const message = `${method} ${url} ${statusCode} ${statusMessage}${responseTime === undefined ? '' : ` ${responseTime}ms`}`;
     this.#logger.error({
       req: {
-        method: req?.options?.method,
-        url: req?.options?.url,
+        method,
+        url,
         failed: true,
       },
       res: {

--- a/src/loggers.ts
+++ b/src/loggers.ts
@@ -90,11 +90,9 @@ export class PinoLogger implements HttpLogger {
   }
 
   logFailure(error: RequestError): void {
-    const { response: res, request: req, timings } = error;
-    // requests that never connect have no request/response/timings — fall back to
-    // the always-present options so the message never interpolates undefined
-    const method = req?.options?.method ?? error.options.method;
-    const url = req?.options?.url ?? error.options.url;
+    const { response: res, timings } = error;
+    // connection-level failures have no response/timings, but options is always set
+    const { method, url } = error.options;
     const responseTimeMs = Number(timings?.end) - Number(timings?.start);
     const responseTime = Number.isNaN(responseTimeMs) ? undefined : responseTimeMs;
     const statusCode = res?.statusCode ?? error.code;


### PR DESCRIPTION
### Summary

- Log all failures. Timeouts, ECONNREFUSED, ECONNRESET were previously not logged by the client at all.
- Fall back to the always-present `error.options` when there is no response, and omit `responseTime` instead of logging `NaNms` — messages like `POST <url> ETIMEDOUT TimeoutError` instead of `undefined undefined undefined Error NaNms`.
- Same url fallback for `GenericLogger`.

### Motivation

Services see literal "undefined" fragments in http-client failure log messages, and upstream connection errors leave no client-side log line to triage from (found while investigating onboarding log noise, EDCL-125).