### PR TITLE
Use npm trusted publishing (OIDC) for CircleCI deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,5 +44,5 @@ jobs:
       - run:
           name: Deploy Package
           command: |
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
             npm publish


### PR DESCRIPTION
Switches the npm `publish` job to trusted publishing (CircleCI OIDC) instead of a static `NPM_TOKEN`.

Publishing was hanging on npm's interactive web 2FA flow in CI; trusted publishing removes the stored secret and isn't subject to that prompt.

- [x] Trusted publisher configured on npmjs.com for this package.