### PR TITLE
Don't swallow CircleCI OIDC token errors in publish step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,5 +44,6 @@ jobs:
       - run:
           name: Deploy Package
           command: |
-            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            export NPM_ID_TOKEN
             npm publish


### PR DESCRIPTION
`export NPM_ID_TOKEN=$(circleci run oidc get ...)` masked a failing OIDC fetch — `export` returns 0, so even under `bash -eo pipefail` the empty token slipped through to `npm publish` (ENEEDAUTH).

Splitting the assignment from `export` lets a failed token fetch fail the step loudly, with the command's stderr in the job log.