### PR TITLE
Upgrade npm before publish so OIDC trusted publishing works

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
       - run:
           name: Deploy Package
           command: |
+            npm install -g npm@latest
             NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
             export NPM_ID_TOKEN
             npm publish


### PR DESCRIPTION
CI's bundled npm (11.6.2) hits a known bug where OIDC trusted publishing fails with a misleading `ENEEDAUTH` despite correct trusted-publisher config (npm/cli#9088). Upgrading npm in the publish job resolves it.

Registry config was ruled out — no project `.npmrc`, no `publishConfig`, default registry matches the OIDC audience.