### PR TITLE
Drop NPM context so OIDC isn't shadowed by NPM_TOKEN

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,11 @@ workflows:
     jobs:
       - build:
           context:
-            - NPM
             - GITHUB
       - publish:
           requires:
             - build
           context:
-            - NPM
             - GITHUB
           filters:
             branches:


### PR DESCRIPTION
The NPM context injects `NPM_TOKEN` into both jobs. A pre-existing `NPM_TOKEN` can make npm short-circuit the OIDC trusted-publishing exchange and then fail with the misleading ENEEDAUTH. OIDC replaces the token, so the context is no longer needed; GITHUB is kept so the jobs still get an OIDC token.

Tested in isolation from the npm-upgrade (PR #63) to see whether removing the context alone fixes publishing.