### PR TITLE
ci: bump node to 24.18.0 and skip duplicate npm publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     working_directory: ~/package
     resource_class: small
     docker:
-      - image: cimg/node:24.11.0
+      - image: cimg/node:24.18.0
     steps:
       - checkout
       - run:
@@ -35,13 +35,18 @@ jobs:
     working_directory: ~/package
     resource_class: small
     docker:
-      - image: cimg/node:24.11.0
+      - image: cimg/node:24.18.0
     steps:
       - attach_workspace:
           at: .
       - run:
           name: Deploy Package
           command: |
+            V=$(node -p "require('./package.json').version")
+            if npm view "tibber-httpclient@$V" version >/dev/null 2>&1; then
+              echo "tibber-httpclient@$V already published, skipping"
+              exit 0
+            fi
             NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
             export NPM_ID_TOKEN
             npm publish


### PR DESCRIPTION
## What
- Bump CircleCI Node image `24.11.0` → `24.18.0` in both `build` and `deploy` jobs.
- Guard the deploy job: skip `npm publish` when `package.json` version is already on the registry.

## Why
- Keep Node runtime current.
- Avoid failed pipelines / duplicate-publish errors when the version hasn't been bumped.