### PR TITLE
Upgrade TypeScript to 5.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prettier": "^3.0.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.3.1",
-    "typescript": "^5.1.6"
+    "typescript": "^5.9.3"
   },
   "dependencies": {
     "fast-copy": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5175,10 +5175,10 @@ typed-array-length@^1.0.4:
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
 
-typescript@^5.1.6:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
-  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
+typescript@^5.9.3:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## What changed

Bumped the `typescript` devDependency from `^5.1.6` to `^5.9.3` (and regenerated `yarn.lock`).

## Why

Keep TypeScript current across our Node apps.

## Verified

- `yarn clean && yarn lint && yarn build:types && esbuild src/index.ts --bundle --platform=node --minify --sourcemap=external --outfile=dist/index.js` — passed with no changes required (via `yarn build`, which runs the same steps).
- `jest --runInBand` — all 64 tests passed.

No source code changes were needed; the newer compiler did not surface any new type errors.